### PR TITLE
electron fix npx create electron app command

### DIFF
--- a/electron/electron.ipynb
+++ b/electron/electron.ipynb
@@ -160,11 +160,11 @@
    "source": [
     "# Initialization\n",
     "```\n",
-    "npx create electron-app@latest my-app\n",
+    "npx create-electron-app my-app\n",
     "```\n",
     "eg\n",
     "```\n",
-    "npx create electron-app@latest bookmarker\n",
+    "npx create-electron-app bookmarker\n",
     "```\n",
     "convert to typescript\n",
     "\n",


### PR DESCRIPTION
This pull request includes a small change to the `electron/electron.ipynb` file. The change updates the command used to create an Electron app to the correct syntax.

* [`electron/electron.ipynb`](diffhunk://#diff-b54b034ff58b822fb2be35f7d8873faae1936d8920f60d239199bc35e2fcda6eL163-R167): Updated the initialization commands from `npx create electron-app@latest` to `npx create-electron-app` to reflect the correct syntax.