### PR TITLE
Electron convert raw to markdown add electron filestructure

### DIFF
--- a/electron/electron.ipynb
+++ b/electron/electron.ipynb
@@ -455,6 +455,19 @@
   {
    "cell_type": "markdown",
    "metadata": {},
+   "source": [
+    "# File structure\n",
+    "The parts of the project are\n",
+    "- `index.html`: Contains all of the HTML markup that provides structure fro our UI\n",
+    "- `main.ts`: Contains the code for our main process\n",
+    "- `renderer.ts`: Contains all the code for interactivity of our UI\n",
+    "- `style.css`: Contains the CSS that styles our UI\n",
+    "- `package.json`: Contains all of our dependencies and points Electron to dist/main.js (compiled from main.ts) when it loads the main process on start-up"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": []
   }
  ],

--- a/electron/electron.ipynb
+++ b/electron/electron.ipynb
@@ -177,14 +177,15 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {
     "vscode": {
      "languageId": "raw"
     }
    },
    "source": [
-    "// tsconfig.json\n",
+    "tsconfig.json\n",
+    "```\n",
     "{\n",
     "  \"compilerOptions\": {\n",
     "    \"target\": \"ES2018\",\n",
@@ -198,7 +199,8 @@
     "    \"baseUrl\": \".\"\n",
     "  },\n",
     "  \"include\": [\"src/**/*\"]\n",
-    "}"
+    "}\n",
+    "```"
    ]
   },
   {
@@ -211,7 +213,7 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {
     "vscode": {
      "languageId": "raw"
@@ -219,6 +221,7 @@
    },
    "source": [
     "package.json\n",
+    "```\n",
     "{\n",
     "  \"name\": \"bookmarker\",\n",
     "  \"productName\": \"bookmarker\",\n",
@@ -252,7 +255,8 @@
     "    \"@electron/fuses\": \"^1.8.0\",\n",
     "    \"electron\": \"35.1.2\"\n",
     "  }\n",
-    "}\n"
+    "}\n",
+    "```"
    ]
   },
   {
@@ -263,9 +267,14 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
    "source": [
+    "```\n",
     "{\n",
     "  \"name\": \"bookmarker\",\n",
     "  \"productName\": \"bookmarker\",\n",
@@ -299,7 +308,8 @@
     "    \"@electron/fuses\": \"^1.8.0\",\n",
     "    \"electron\": \"35.1.2\"\n",
     "  }\n",
-    "}\n"
+    "}\n",
+    "```"
    ]
   },
   {
@@ -310,7 +320,7 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {
     "vscode": {
      "languageId": "raw"
@@ -318,6 +328,7 @@
    },
    "source": [
     "// package.json\n",
+    "```\n",
     "\"main\": \"dist/main.js\",\n",
     "\n",
     "\"scripts\": {\n",
@@ -329,7 +340,8 @@
     "  \"make\": \"npm run build && electron-forge make\",\n",
     "  \"publish\": \"npm run build && electron-forge publish\",\n",
     "  \"lint\": \"echo \\\"No linting configured\\\"\"\n",
-    "},"
+    "},\n",
+    "```"
    ]
   },
   {


### PR DESCRIPTION
This pull request includes a small change to the `electron/electron.ipynb` file. The change updates the command used to create an Electron app to the correct syntax.

* [`electron/electron.ipynb`](diffhunk://#diff-b54b034ff58b822fb2be35f7d8873faae1936d8920f60d239199bc35e2fcda6eL163-R167): Updated the initialization commands from `npx create electron-app@latest` to `npx create-electron-app` to reflect the correct syntax.
This pull request includes changes to the `electron/electron.ipynb` file to convert several code cells from "raw" to "markdown" format and to properly format code blocks with markdown syntax.

Formatting improvements:

* Changed multiple cells from `raw` to `markdown` to improve readability and ensure proper rendering of code blocks. [[1]](diffhunk://#diff-b54b034ff58b822fb2be35f7d8873faae1936d8920f60d239199bc35e2fcda6eL180-R188) [[2]](diffhunk://#diff-b54b034ff58b822fb2be35f7d8873faae1936d8920f60d239199bc35e2fcda6eL214-R224) [[3]](diffhunk://#diff-b54b034ff58b822fb2be35f7d8873faae1936d8920f60d239199bc35e2fcda6eL266-R277) [[4]](diffhunk://#diff-b54b034ff58b822fb2be35f7d8873faae1936d8920f60d239199bc35e2fcda6eL313-R331)
* Added markdown code block delimiters (```) around JSON content to ensure proper formatting and syntax highlighting. [[1]](diffhunk://#diff-b54b034ff58b822fb2be35f7d8873faae1936d8920f60d239199bc35e2fcda6eL201-R203) [[2]](diffhunk://#diff-b54b034ff58b822fb2be35f7d8873faae1936d8920f60d239199bc35e2fcda6eL255-R259) [[3]](diffhunk://#diff-b54b034ff58b822fb2be35f7d8873faae1936d8920f60d239199bc35e2fcda6eL302-R312) [[4]](diffhunk://#diff-b54b034ff58b822fb2be35f7d8873faae1936d8920f60d239199bc35e2fcda6eL332-R344)

Content enhancements:

* Added a new markdown cell to describe the file structure of the project, providing a clear overview of the project's components.