### PR TITLE
electron set -  and -  for typescript conversion

### DIFF
--- a/electron/electron.ipynb
+++ b/electron/electron.ipynb
@@ -263,7 +263,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "lets change our main script to main.js"
+    "lets change our main script to main.ts\n",
+    "\n",
+    "add the following fields to webPreferences:\n",
+    "- `nodeIntegration: true,`\n",
+    "- `contextIsolation: false,`\n",
+    "```\n",
+    "const createWindow = (): void => {\n",
+    "  // Create the browser window.\n",
+    "  const mainWindow = new BrowserWindow({\n",
+    "    webPreferences: {\n",
+    "      nodeIntegration: true,       // Enable this\n",
+    "      contextIsolation: false,     // Disable this\n",
+    "      preload: path.join(__dirname, 'preload.js'),\n",
+    "    },\n",
+    "  });\n",
+    "\n",
+    "  // and load the index.html of the app.\n",
+    "  mainWindow.loadFile(path.join(__dirname, 'index.html'));\n",
+    "\n",
+    "  // Open the DevTools.\n",
+    "  mainWindow.webContents.openDevTools();\n",
+    "};\n",
+    "```"
    ]
   },
   {


### PR DESCRIPTION
This pull request includes updates to the `electron/electron.ipynb` file to change the main script from JavaScript to TypeScript and modify the web preferences for the Electron application.

Changes to the main script and web preferences:

* Changed the main script from `main.js` to `main.ts`.
* Updated `webPreferences` to enable `nodeIntegration` and disable `contextIsolation`.
* Added a code snippet to illustrate the changes in the `createWindow` function.